### PR TITLE
First scenario

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,2 @@
+exit
+field

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'jquery-rails'
 
 group :development do
   gem 'annotate'
+  gem 'byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       rake (>= 10.4, < 13.0)
     arel (8.0.0)
     builder (3.2.3)
+    byebug (10.0.2)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -205,6 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  byebug
   capybara
   cucumber-rails
   database_cleaner
@@ -220,4 +222,4 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/mad_lib.rb
+++ b/app/models/mad_lib.rb
@@ -1,2 +1,8 @@
+require 'byebug'
+
 class MadLib < ApplicationRecord
+
+  def has_field?(field)
+    byebug
+  end
 end

--- a/app/models/mad_lib.rb
+++ b/app/models/mad_lib.rb
@@ -1,0 +1,2 @@
+class MadLib < ApplicationRecord
+end

--- a/app/models/mad_lib.rb
+++ b/app/models/mad_lib.rb
@@ -1,8 +1,21 @@
 require 'byebug'
 
 class MadLib < ApplicationRecord
+  # this finds the parts of speech (fields) within the given text from the MadLib model
+  def field_reg_ex
+    /\{([^}]+)\}/
+  end
+
+  def find_fields
+    text.scan(field_reg_ex)
+  end
+
+  def count_fields
+    find_fields.each_with_object(Hash.new(0)) { |field, count| count[field] += 1 }
+  end
 
   def has_field?(field)
     byebug
+    field
   end
 end

--- a/app/models/mad_lib.rb
+++ b/app/models/mad_lib.rb
@@ -1,6 +1,8 @@
 require 'byebug'
 
 class MadLib < ApplicationRecord
+  attr_reader :formatted_fields
+
   # this finds the parts of speech (fields) within the given text from the MadLib model
   def field_reg_ex
     /\{([^}]+)\}/
@@ -14,8 +16,14 @@ class MadLib < ApplicationRecord
     find_fields.each_with_object(Hash.new(0)) { |field, count| count[field] += 1 }
   end
 
+  def format_fields
+    @formatted_fields = []
+    count_fields.each {|field, count| @formatted_fields << "#{field.first.capitalize} (#{count}):"}
+  end
+
   def has_field?(field)
     byebug
-    field
+    format_fields
+    @formatted_fields.include? field
   end
 end

--- a/app/models/mad_lib.rb
+++ b/app/models/mad_lib.rb
@@ -1,7 +1,7 @@
 require 'byebug'
 
 class MadLib < ApplicationRecord
-  attr_reader :formatted_fields
+  attr_reader :labeled_fields
 
   # this finds the parts of speech (fields) within the given text from the MadLib model
   def field_reg_ex
@@ -9,21 +9,26 @@ class MadLib < ApplicationRecord
   end
 
   def find_fields
-    text.scan(field_reg_ex)
+    text.scan(field_reg_ex).flatten
   end
 
   def count_fields
-    find_fields.each_with_object(Hash.new(0)) { |field, count| count[field] += 1 }
+    find_fields.each_with_object(Hash.new(0)) { |field, count| count[field] += 1}
   end
 
-  def format_fields
-    @formatted_fields = []
-    count_fields.each {|field, count| @formatted_fields << "#{field.first.capitalize} (#{count}):"}
+  def label_fields
+    @labeled_fields = []
+
+    count_fields.each do |field, count|
+      index = 0
+      count.times do
+        @labeled_fields << "#{field.capitalize} (#{index += 1}):"
+      end
+    end
+    @labeled_fields
   end
 
-  def has_field?(field)
-    byebug
-    format_fields
-    @formatted_fields.include? field
+  def has_field?(label)
+    label_fields.include? label
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,7 +24,7 @@ Madlibs::Application.configure do
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false

--- a/db/migrate/20180819201924_create_mad_libs.rb
+++ b/db/migrate/20180819201924_create_mad_libs.rb
@@ -1,0 +1,8 @@
+class CreateMadLibs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :mad_libs do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180819201924_create_mad_libs.rb
+++ b/db/migrate/20180819201924_create_mad_libs.rb
@@ -1,6 +1,7 @@
 class CreateMadLibs < ActiveRecord::Migration[5.1]
   def change
     create_table :mad_libs do |t|
+      t.text :text
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 20180819201924) do
 
   create_table "mad_libs", force: :cascade do |t|
+    t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180819201924) do
+
+  create_table "mad_libs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/features/step_definitions/mad_lib_steps.rb
+++ b/features/step_definitions/mad_lib_steps.rb
@@ -4,7 +4,7 @@ end
 
 Then /^it should have the following fields:$/ do |table|
   table.hashes.each do |field|
-    @madlib.has_field?(field[:label]).should be_true
+    @madlib.has_field?(field[:label]).should be true
   end
 end
 


### PR DESCRIPTION
This PR sets up the MadLib model, schema, and migrations and passes tests 1-4 🎉 

Difficulties:
- It turns out that auto_explain_threshold_in_seconds is a config that [should have been removed when upgrading](https://guides.rubyonrails.org/4_0_release_notes.html#active-record-notable-changes) the app to rails 4. After [commenting it out](https://github.com/gabezurita/mad_libs/commit/1cce96ef291e86b70ca467dc7e4953b0815e41e6), I was able to run `rails generate model mad_lib` successfully.
- The cucumber file was using [deprecated `be_true` rspec syntax](https://github.com/rspec/rspec-rails/issues/976). I updated this to `be true` to get the tests running correctly.